### PR TITLE
Feat: Edits a bulk discount and taken back to show page with updated …

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -5,6 +5,7 @@ class BulkDiscountsController < ApplicationController
     end
 
     def show
+        @bulk_discount = BulkDiscount.find(params[:id])
         @merchant = Merchant.find(params[:merchant_id])
     end
 
@@ -24,9 +25,26 @@ class BulkDiscountsController < ApplicationController
         redirect_to (merchant_bulk_discounts_path(params[:merchant_id]))
     end
 
+    def edit
+        @bulk_discount = BulkDiscount.find(params[:id])
+        @merchant = Merchant.find(params[:merchant_id])
+    end
+
+    def update
+        merchant = Merchant.find(params[:merchant_id])
+        bulk_discount = BulkDiscount.find(params[:id])
+        if bulk_discount.update(bulk_discount_params)
+          redirect_to merchant_bulk_discount_path(merchant, bulk_discount)
+        end
+    end
+
     private
 
     def bulk_discount_params
-        params.permit(:percentage_discount, :quantity_threshold, :merchant_id)
+        if params[:action] == 'create'
+            params.require(:bulk_discount).permit(:percentage_discount, :quantity_threshold).merge(merchant_id: params[:merchant_id])
+        else
+            params.require(:bulk_discount).permit(:percentage_discount, :quantity_threshold)
+        end
     end
 end

--- a/app/models/bulk_discount.rb
+++ b/app/models/bulk_discount.rb
@@ -1,3 +1,6 @@
 class BulkDiscount < ApplicationRecord
+  validates_presence_of :percentage_discount
+  validates_presence_of :quantity_threshold
+
   belongs_to :merchant
 end

--- a/app/views/bulk_discounts/_form.html.erb
+++ b/app/views/bulk_discounts/_form.html.erb
@@ -1,0 +1,17 @@
+<%# locals: (model:, path:, method:, button_name:) - %>
+
+<%= form_with model: model, url: path, method: method, local: true do |form| %>
+    <div>
+    <%= form.label :percentage_discount, "Percentage Discount" %>
+    <%= form.number_field :percentage_discount, in: 0..1, step: 0.01, value: model.percentage_discount unless model.new_record?%>
+    <%= form.number_field :percentage_discount, in: 0..1, step: 0.01 if model.new_record?%>
+    </div>
+    <div>
+    <%= form.label :quantity_threshold, "Quantity Threshold" %>
+    <%= form.number_field :quantity_threshold, value: model.quantity_threshold unless model.new_record?%>
+    <%= form.number_field :quantity_threshold if model.new_record?%>
+    </div>
+    <div>
+    <%= form.submit button_name %>
+    </div>
+<% end %>

--- a/app/views/bulk_discounts/edit.html.erb
+++ b/app/views/bulk_discounts/edit.html.erb
@@ -1,0 +1,6 @@
+<%= render partial: 'form', locals: { 
+  model: @bulk_discount,
+  path: merchant_bulk_discount_path(@merchant, @bulk_discount), 
+  method: :patch,
+  button_name: "Submit"
+  }%>

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -8,4 +8,4 @@
     </section>
 <%end%>
 
-<h4> <%=link_to "Create New Discount", new_merchant_bulk_discount_path(@merchant) %> </h4>
+<h4> <%=link_to "Create New Discount", new_merchant_bulk_discount_path(@merchant)%> </h4>

--- a/app/views/bulk_discounts/new.html.erb
+++ b/app/views/bulk_discounts/new.html.erb
@@ -1,15 +1,8 @@
 <h1>Create a new Bulk Discount!</h1>
 
-<%= form_with url: merchant_bulk_discounts_path(@merchant)do |form| %>
-    <div>
-    <%= form.label :percentage_discount, "Percentage Discount" %>
-    <%= form.number_field :percentage_discount, in: 0..1, step: 0.01%>
-    </div>
-    <div>
-    <%= form.label :quantity_threshold, "Quantity Threshold" %>
-    <%= form.number_field :quantity_threshold%>
-    </div>
-    <div>
-    <%= form.submit 'Create' %>
-    </div>
-<% end %>
+<%= render partial: 'form', locals: { 
+  model: @bulk_discount,
+  path: merchant_bulk_discounts_path(@merchant), 
+  method: :post,
+  button_name: "Create"
+  }%>

--- a/app/views/bulk_discounts/show.html.erb
+++ b/app/views/bulk_discounts/show.html.erb
@@ -1,7 +1,7 @@
-<% @merchant.bulk_discounts.each do |bulk_discount| %>
-    <h2> Bulk Discount - <%=bulk_discount.id%> </h2>
+    <h2> Bulk Discount - <%=@bulk_discount.id%> </h2>
     <ul>
-        <li> Percentage discount: <%=float_to_percent(bulk_discount.percentage_discount)%> </li>
-        <li> Quantity threshold: <%=bulk_discount.quantity_threshold%> </li>
-    </ul>    
-<%end%>
+        <li> Percentage discount: <%=float_to_percent(@bulk_discount.percentage_discount)%> </li>
+        <li> Quantity threshold: <%=@bulk_discount.quantity_threshold%> </li>
+    </ul>  
+
+    <%= link_to "Edit Bulk Discount", edit_merchant_bulk_discount_path(@merchant, @bulk_discount) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy]
+    resources :bulk_discounts
   end
 
   namespace :admin do

--- a/spec/features/bulk_discounts/show_spec.rb
+++ b/spec/features/bulk_discounts/show_spec.rb
@@ -19,4 +19,28 @@ RSpec.describe 'Merchant bulk discounts show page' do
         expect(page).to have_content("Quantity threshold: 20")
     end
 
+    it 'can edit a bulk discount' do
+        # As a merchant
+        # When I visit my bulk discount show page
+        # Then I see a link to edit the bulk discount
+        expect(page).to have_link("Edit Bulk Discount")
+        # When I click this link
+        click_link "Edit Bulk Discount"
+        # Then I am taken to a new page with a form to edit the discount
+        expect(current_path).to eq edit_merchant_bulk_discount_path(@merchant1, @bulk_discount2)
+        # And I see that the discounts current attributes are pre-poluated in the form
+        expect(page).to have_field("Percentage Discount", with: "0.3")
+        expect(page).to have_field("Quantity Threshold", with: "20")
+        # When I change any/all of the information and click submit
+        fill_in "Percentage Discount", with: "0.65"
+        fill_in "Quantity Threshold", with: "35"
+
+        click_button "Submit"
+        # Then I am redirected to the bulk discount's show page
+        expect(current_path).to eq merchant_bulk_discount_path(@merchant1, @bulk_discount2)
+        # And I see that the discount's attributes have been updated
+        expect(page).to have_content("Percentage discount: 65.00%")
+        expect(page).to have_content("Quantity threshold: 35")
+    end
+
 end


### PR DESCRIPTION
5: Merchant Bulk Discount Edit

As a merchant
When I visit my bulk discount show page
Then I see a link to edit the bulk discount
When I click this link
Then I am taken to a new page with a form to edit the discount
And I see that the discounts current attributes are pre-poluated in the form
When I change any/all of the information and click submit
Then I am redirected to the bulk discount's show page
And I see that the discount's attributes have been updated